### PR TITLE
Dependencies conflict with other Omnipay Payment Gateways

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "omnipay/common": "3.0-beta.1",
+        "omnipay/common": "~3.0",
         "php-http/guzzle6-adapter": "^1.1"
     },
     "require-dev": {
-        "omnipay/tests": "3.0-beta.1"
+        "omnipay/tests": "~3.0"
     },
     "autoload": {
         "psr-4": { "Omnipay\\Midtrans\\" : "src/" }

--- a/tests/Message/SnapWindowRedirectionPurchaseRequestTest.php
+++ b/tests/Message/SnapWindowRedirectionPurchaseRequestTest.php
@@ -9,6 +9,7 @@
 namespace Omnipay\Midtrans\Message;
 
 use Omnipay\Tests\TestCase;
+use Omnipay\Common\Exception\InvalidRequestException;
 
 class TestSnapWindowRedirectionPurchaseRequest extends SnapWindowRedirectionPurchaseRequest
 {
@@ -86,6 +87,9 @@ class SnapWindowRedirectionPurchaseRequestTest extends TestCase
                     'brand' => 'Marina Run 2016',
                 ]
             ],
+            'credit_card' => [
+                'secure' => true
+            ],
             'customer_details' => [
                 'first_name' => 'Xu',
                 'last_name' => 'Ding',
@@ -104,10 +108,8 @@ class SnapWindowRedirectionPurchaseRequestTest extends TestCase
 
         $this->request->initialize($baseData);
 
-        $this->setExpectedException(
-            '\Omnipay\Common\Exception\InvalidRequestException',
-            'The amount parameter is required'
-        );
+        $this->expectException(InvalidRequestException::class);
+        $this->expectExceptionMessage('The amount parameter is required');
 
         $this->request->getData();
     }
@@ -121,9 +123,7 @@ class SnapWindowRedirectionPurchaseRequestTest extends TestCase
 
         $this->request->initialize($baseData);
 
-        $this->setExpectedException(
-            '\Omnipay\Common\Exception\InvalidRequestException'
-        );
+        $this->expectException(InvalidRequestException::class);
 
         $this->request->getData();
     }
@@ -135,9 +135,7 @@ class SnapWindowRedirectionPurchaseRequestTest extends TestCase
             'amount' => '10000.00'
         ]);
 
-        $this->setExpectedException(
-            '\Omnipay\Common\Exception\InvalidRequestException'
-        );
+        $this->expectException(InvalidRequestException::class);
 
         $this->request->getData();
     }
@@ -150,9 +148,7 @@ class SnapWindowRedirectionPurchaseRequestTest extends TestCase
             'transactionId' => '@123'
         ]);
 
-        $this->setExpectedException(
-            '\Omnipay\Common\Exception\InvalidRequestException'
-        );
+        $this->expectException(InvalidRequestException::class);
 
         $this->request->getData();
 


### PR DESCRIPTION
````
Using version ^2.0 for dilab/omnipay-midtrans
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - dilab/omnipay-midtrans 2.0.1 requires omnipay/common 3.0-beta.1 -> satisfiable by omnipay/common[v3.0-beta.1] but these conflict with your requirements or minimum-stability.
    - dilab/omnipay-midtrans 2.0.0 requires omnipay/common 3.0-beta.1 -> satisfiable by omnipay/common[v3.0-beta.1] but these conflict with your requirements or minimum-stability.
    - Installation request for dilab/omnipay-midtrans ^2.0 -> satisfiable by dilab/omnipay-midtrans[2.0.0, 2.0.1].


Installation failed, reverting ./composer.json to its original content.
````

Need to update the omnipay/common to 3.0 in composer.json.

Thanks
